### PR TITLE
Recursively resolve map values

### DIFF
--- a/src/visitor.js
+++ b/src/visitor.js
@@ -74,7 +74,15 @@ export default class Visitor {
       props = args;
     }
 
-    return props.reduce((acc, prop) => (acc[prop]), this.maps[name]);
+    let value = props.reduce((acc, prop) => (acc[prop]), this.maps[name]);
+
+    if (!reMap.test(value)) {
+      return value;
+    }
+
+    return rfc(value, 'map', body => {
+      return this.getValue(list.comma(body));
+    });
   }
 
   /**

--- a/test/fixture/recursive.yml
+++ b/test/fixture/recursive.yml
@@ -1,0 +1,2 @@
+foo: map(dummy, foo)
+bar: map(recursive, foo)

--- a/test/fixture/recursive/expected.css
+++ b/test/fixture/recursive/expected.css
@@ -1,0 +1,7 @@
+.foo {
+  content: foo value;
+}
+
+.bar {
+  content: foo value;
+}

--- a/test/fixture/recursive/input.css
+++ b/test/fixture/recursive/input.css
@@ -1,0 +1,7 @@
+.foo {
+  content: map(recursive, foo);
+}
+
+.bar {
+  content: map(recursive, bar);
+}

--- a/test/map.test.js
+++ b/test/map.test.js
@@ -15,12 +15,24 @@ let opts = {
     'breakpoints.yml',
     'assets.yml',
     'config.yml',
+    'recursive.yml',
   ],
 };
 
 test('value', async () => {
   const input = read('value/input.css');
   const expected = read('value/expected.css');
+
+  const result = await postcss()
+    .use(plugin(opts))
+    .process(input, { from });
+
+  expect(result.css).toBe(expected);
+});
+
+test('recursive', async () => {
+  const input = read('recursive/input.css');
+  const expected = read('recursive/expected.css');
 
   const result = await postcss()
     .use(plugin(opts))


### PR DESCRIPTION
Closes #118

Recursively resolves map values so you can access maps within your maps. Consider the following example.

colors.yal

    red: '#b71c1c'

palette.yal

    main: map(colors, red)

input 

    a {
      color: map(palette, main);
    }

output

    a {
        color: #b71c1c;
    }

This would also work for referencing values within the same map.

palette.yml

    main: '#b71c1c'
    text-color: map(palette, main)